### PR TITLE
Updates.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": [
     "metalab/base",
-    "metalab/node"
+    "metalab/react"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "redux-promise-wait": "^0.1.1",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"
+  },
+  "dependencies": {
+    "htmlescape": "^1.1.0"
   }
 }


### PR DESCRIPTION
Use react preset in `.eslintrc`.
Include missing `htmlescape` dependency.
