### PR TITLE
Generate external source maps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "nealgranger/react-redux-render",
   "main": "index.js",
   "scripts": {
-    "build": "node_modules/.bin/babel -s inline -d . src/",
+    "build": "node_modules/.bin/babel -s -d . src/",
     "lint": "node_modules/.bin/eslint .",
     "prepublish": "npm run build",
     "spec": "NODE_ENV=test node_modules/.bin/mocha --compilers js:babel-core/register -r adana-dump -R spec test/spec",


### PR DESCRIPTION
Inline source maps were causing issues with webpack's source mapping. Moving them to separate `.map` files to fix the issue.
